### PR TITLE
Change the order of categorical plot

### DIFF
--- a/docs/categorical/cat_num.md
+++ b/docs/categorical/cat_num.md
@@ -471,3 +471,56 @@ canvas = new_canvas("matplotlib")
     .with_outliers(size=8)
 )
 ```
+
+## Sort categorical axis
+
+By default, the order of the categories is determined by the order of appearance in the
+data. In the example data, the order of `"category"` is "A" and "B".
+
+If you want to sort the categories as you like, you can use the sorting methods of the
+categorical plotters.
+
+### Sort in ascending or descending order
+
+The `sort` method will sort the categories in ascending or descending order. The default
+is ascending. Use `ascending=False` to sort in descending order.
+
+``` python hl_lines="5"
+#!name: categorical_axis_sort_descending
+canvas = new_canvas("matplotlib")
+(
+    canvas
+    .cat_x(df, x="category", y="observation")
+    .sort(ascending=False)
+    .add_violinplot(color="replicate")
+)
+```
+
+Sorting works similarly for the categorical axis with multiple columns.
+
+``` python hl_lines="4"
+#!name: categorical_axis_sort_descending_multiple
+canvas = new_canvas("matplotlib")
+(
+    canvas
+    .cat_x(df, x=["category", "replicate"], y="observation")
+    .sort(ascending=False)
+    .add_violinplot(color="replicate")
+)
+```
+
+### Sort in any order
+
+If you already know the category names and want to sort them in a certain order, use the
+`sort_in_order` method.
+
+``` python hl_lines="5"
+#!name: categorical_axis_sort_manual
+canvas = new_canvas("matplotlib")
+(
+    canvas
+    .cat_x(df, x="category", y="observation")
+    .sort_in_order(["B", "A"])
+    .add_violinplot(color="replicate")
+)
+```

--- a/tests/test_logics.py
+++ b/tests/test_logics.py
@@ -91,10 +91,38 @@ def test_sort():
         "y": ["p"] * 20 + ["q"] * 20,
         "val": rng.normal(size=40),
     }
+
+    # simple
     canvas = new_canvas(backend="mock")
     canvas.cat_x(df, "x", "val").sort_in_order(["b", "a", "c"]).add_boxplot()
     assert canvas.x.ticks.labels == ["b", "a", "c"]
 
+    # with color
+    canvas = new_canvas(backend="mock")
+    canvas.cat_x(df, "x", "val").sort_in_order(["b", "a", "c"]).add_boxplot(color="y")
+    assert canvas.x.ticks.labels == ["b", "a", "c"]
+
+    # ascending sort
+    canvas = new_canvas(backend="mock")
+    canvas.cat_x(df, "x", "val").sort(ascending=True).add_stripplot()
+    assert canvas.x.ticks.labels == ["a", "b", "c"]
+
+    # descending sort
+    canvas = new_canvas(backend="mock")
+    canvas.cat_x(df, "x", "val").sort(ascending=False).add_stripplot()
+    assert canvas.x.ticks.labels == ["c", "b", "a"]
+
+    # two keys
+    canvas = new_canvas(backend="mock")
+    (
+        canvas
+        .cat_y(df, "val", ["x", "y"])
+        .sort_in_order([("b", "q"), ("a", "p"), ("c", "q"), ("c", "p"), ("a", "q"), ("b", "p")])
+        .add_swarmplot()
+    )
+    assert canvas.y.ticks.labels == ["b\nq", "a\np", "c\nq", "c\np", "a\nq", "b\np"]
+
+    # xy categorical plotter
     canvas = new_canvas(backend="mock")
     (
         canvas

--- a/tests/test_logics.py
+++ b/tests/test_logics.py
@@ -84,6 +84,28 @@ def test_melt():
     df = {"x": rng.normal(size=15), "y": rng.normal(size=15)}
     canvas.cat_x(df).melt().add_boxplot(color="variable")
 
+def test_sort():
+    rng = np.random.default_rng(1642)
+    df = {
+        "x": ["a"] * 14 + ["b"] * 10 + ["c"] * 16,
+        "y": ["p"] * 20 + ["q"] * 20,
+        "val": rng.normal(size=40),
+    }
+    canvas = new_canvas(backend="mock")
+    canvas.cat_x(df, "x", "val").sort_in_order(["b", "a", "c"]).add_boxplot()
+    assert canvas.x.ticks.labels == ["b", "a", "c"]
+
+    canvas = new_canvas(backend="mock")
+    (
+        canvas
+        .cat_xy(df, "x", "y")
+        .sort_in_order(x=["b", "a", "c"], y=["q", "p"])
+        .mean()
+        .add_heatmap("val")
+    )
+    assert canvas.x.ticks.labels == ["b", "a", "c"]
+    assert canvas.y.ticks.labels == ["q", "p"]
+
 def test_matplotlib_tooltip():
     canvas = new_canvas(backend="matplotlib")
     canvas.add_markers([1, 2, 3], [4, 5, 6])

--- a/whitecanvas/canvas/dataframe/_base.py
+++ b/whitecanvas/canvas/dataframe/_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import weakref
 from typing import (
     TYPE_CHECKING,
+    Callable,
     Generic,
     Iterator,
     Literal,
@@ -56,11 +57,15 @@ class CatIterator(Generic[_DF]):
         df: DataFrameWrapper[_DF],
         offsets: tuple[str, ...],
         numeric: bool = False,
+        sort_func: Callable[[tuple], int] | None = None,
     ):
         self._df = df
         self._offsets = offsets
         self._cat_map_cache = {}
         self._numeric = numeric
+        if sort_func is not None and numeric:
+            raise ValueError("sort_func is not allowed for numeric data.")
+        self._sort_func = sort_func
 
     @property
     def df(self) -> DataFrameWrapper[_DF]:
@@ -70,19 +75,19 @@ class CatIterator(Generic[_DF]):
     def offsets(self) -> tuple[str, ...]:
         return self._offsets
 
-    def category_map(self, columns: tuple[str, ...] | None = None) -> dict[tuple, int]:
+    def category_map(self, columns: tuple[str, ...]) -> dict[tuple, int]:
         """Calculate how to map category columns to integers."""
-        if columns is None:
-            key = self._offsets
-        else:
-            key = tuple(columns)
-        if key in self._cat_map_cache:
-            return self._cat_map_cache[key]
-        if len(key) == 0:
+        columns = tuple(columns)
+        if columns in self._cat_map_cache:
+            return self._cat_map_cache[columns]
+        if len(columns) == 0:
             return {(): 0}
-        columns = [self._df[c] for c in key]
-        _map = {uni: i for i, uni in enumerate(OrderedSet(zip(*columns)))}
-        self._cat_map_cache[key] = _map
+        serieses = [self._df[c] for c in columns]
+        if self._sort_func is None:
+            _map = {uni: i for i, uni in enumerate(OrderedSet(zip(*serieses)))}
+        else:
+            _map = {uni: self._sort_func(uni) for uni in set(zip(*serieses))}
+        self._cat_map_cache[columns] = _map
         return _map
 
     def iter_arrays(
@@ -91,6 +96,16 @@ class CatIterator(Generic[_DF]):
         dodge: tuple[str, ...] | None = None,
         width: float = 0.8,
     ) -> Iterator[tuple[tuple, float, DataFrameWrapper[_DF]]]:
+        """
+        Iterate over the groups of the DataFrame for plotting.
+
+        Returns
+        -------
+        Iterator of (tuple, float, DataFrameWrapper[_DF])
+            The first tuple is the group key, the second float is the x (or y)
+            coordinate the group should be plotted at, and the third is the subset
+            of the DataFrame that corresponds to the group.
+        """
         if dodge is None:
             dodge = ()
         if set(self._offsets) > set(by):
@@ -156,12 +171,14 @@ class CatIterator(Generic[_DF]):
         return out
 
     def axis_ticks(self) -> tuple[list[float], list[str]]:
-        pos = []
-        labels = []
+        """Prepare the axis ticks and labels for the category plot."""
+        pos: list[float] = []
+        labels: list[str] = []
         for k, v in self.category_map(self._offsets).items():
             pos.append(v)
             labels.append("\n".join(map(str, k)))
-        return pos, labels
+        pos_indices = np.argsort(pos)
+        return [pos[i] for i in pos_indices], [labels[i] for i in pos_indices]
 
     def axis_label(self) -> str:
         return "/".join(self._offsets)

--- a/whitecanvas/canvas/dataframe/_both_cat.py
+++ b/whitecanvas/canvas/dataframe/_both_cat.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, TypeVar
 
 import numpy as np
 
+from whitecanvas.canvas.dataframe import _misc
 from whitecanvas.canvas.dataframe._base import BaseCatPlotter, CatIterator
-from whitecanvas.canvas.dataframe._misc import make_sorter
 from whitecanvas.layers import tabular as _lt
 from whitecanvas.layers.tabular import _jitter
 from whitecanvas.types import ColormapType
@@ -87,8 +87,8 @@ class XYCatPlotter(BaseCatPlotter[_C, _DF]):
     def sort_in_order(
         self,
         *,
-        x: Sequence[Any],
-        y: Sequence[Any],
+        x: Sequence[Any] | None = None,
+        y: Sequence[Any] | None = None,
     ) -> Self:
         """
         Sort the data in the given order.
@@ -100,16 +100,48 @@ class XYCatPlotter(BaseCatPlotter[_C, _DF]):
         y : sequence of any
             The order to sort the y-axis data.
         """
-        x_normed = tuple(u if isinstance(u, tuple) else (u,) for u in x)
-        y_normed = tuple(u if isinstance(u, tuple) else (u,) for u in y)
+        if x is not None:
+            x_sorter = _misc.make_sorter_manual(
+                [u if isinstance(u, tuple) else (u,) for u in x]
+            )
+        else:
+            x_sorter = None
+        if y is not None:
+            y_sorter = _misc.make_sorter_manual(
+                [u if isinstance(u, tuple) else (u,) for u in y]
+            )
+        else:
+            y_sorter = None
+
         return type(self)(
             self._canvas(),
             self._df,
             x=self._x,
             y=self._y,
             update_labels=self._update_label,
-            x_sorter=make_sorter(x_normed),
-            y_sorter=make_sorter(y_normed),
+            x_sorter=x_sorter,
+            y_sorter=y_sorter,
+        )
+
+    def sort(self, *, x_ascending: bool = True, y_ascending: bool = True) -> Self:
+        """
+        Sort the categories in ascending or descending order.
+
+        Parameters
+        ----------
+        x_ascending : bool, default True
+            Sort the x-axis categories in ascending order.
+        y_ascending : bool, default True
+            Sort the y-axis categories in ascending order.
+        """
+        return type(self)(
+            self._canvas(),
+            self._df,
+            x=self._x,
+            y=self._y,
+            update_labels=self._update_label,
+            x_sorter=_misc.sorter_ascending if x_ascending else _misc.sorter_descending,
+            y_sorter=_misc.sorter_ascending if y_ascending else _misc.sorter_descending,
         )
 
     def _update_xy_label(

--- a/whitecanvas/canvas/dataframe/_misc.py
+++ b/whitecanvas/canvas/dataframe/_misc.py
@@ -1,15 +1,34 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Callable, Sequence, TypeVar
+
+_T = TypeVar("_T")
 
 
-def make_sorter(order: tuple[Any, ...]) -> Callable[[tuple], int]:
-    def _sort_in_order(val: tuple[Any, ...]) -> int:
-        try:
-            return order.index(val)
-        except ValueError:
+def make_sorter_manual(order: Sequence[_T]) -> Callable[[Sequence[_T]], Sequence[_T]]:
+    if len(order) != len(set(order)):
+        raise ValueError(f"Order contains duplicate values: {order!r}")
+
+    def _sort_manual(x: Sequence[_T]) -> Sequence[_T]:
+        out: list[_T] = []
+        input_categories = set(x)
+        for each in order:
+            if each in input_categories:
+                out.append(each)
+                input_categories.discard(each)
+        if input_categories:
             raise ValueError(
-                f"Value {val!r} is in the data but not given in the order."
+                f"Categories {input_categories!r} are not in the given order "
+                f"{order!r}"
             )
+        return order
 
-    return _sort_in_order
+    return _sort_manual
+
+
+def sorter_ascending(x: Sequence[_T]) -> Sequence[_T]:
+    return sorted(x)
+
+
+def sorter_descending(x: Sequence[_T]) -> Sequence[_T]:
+    return sorted(x, reverse=True)

--- a/whitecanvas/canvas/dataframe/_misc.py
+++ b/whitecanvas/canvas/dataframe/_misc.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def make_sorter(order: tuple[Any, ...]) -> Callable[[tuple], int]:
+    def _sort_in_order(val: tuple[Any, ...]) -> int:
+        try:
+            return order.index(val)
+        except ValueError:
+            raise ValueError(
+                f"Value {val!r} is in the data but not given in the order."
+            )
+
+    return _sort_in_order

--- a/whitecanvas/canvas/dataframe/_one_cat.py
+++ b/whitecanvas/canvas/dataframe/_one_cat.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Sequence, TypeVar
 import numpy as np
 
 from whitecanvas import theme
+from whitecanvas.canvas.dataframe import _misc
 from whitecanvas.canvas.dataframe._base import AggMethods, BaseCatPlotter, CatIterator
-from whitecanvas.canvas.dataframe._misc import make_sorter
 from whitecanvas.layers import tabular as _lt
 from whitecanvas.layers.tabular import _jitter, _shared
 from whitecanvas.types import (
@@ -254,7 +254,7 @@ class OneAxisCatPlotter(BaseCatPlotter[_C, _DF]):
 
     def sort_in_order(self, order: Sequence[Any]) -> Self:
         """
-        Sort the data in the given order.
+        Sort the categories in the given order.
 
         Parameters
         ----------
@@ -264,8 +264,26 @@ class OneAxisCatPlotter(BaseCatPlotter[_C, _DF]):
         order_normed = tuple(u if isinstance(u, tuple) else (u,) for u in order)
         return type(self)(
             self._canvas(), self._df, self._offset, self._value, self._update_labels,
-            sort_func=make_sorter(order_normed)
+            sort_func=_misc.make_sorter_manual(order_normed)
         )  # fmt: skip
+
+    def sort(self, *, ascending: bool = True) -> Self:
+        """
+        Sort the categories in ascending or descending order.
+
+        Parameters
+        ----------
+        ascending : bool, default True
+            Whether to sort the data in ascending order.
+        """
+        return type(self)(
+            self._canvas(),
+            self._df,
+            self._offset,
+            self._value,
+            self._update_labels,
+            sort_func=_misc.sorter_ascending if ascending else _misc.sorter_descending,
+        )
 
     ### 1-D categorical ###
 


### PR DESCRIPTION
To set the order of categorical axis we have to sort the DataFrame all the way.
This PR adds `sort_in_order` method to avoid this trouble.

```python
layer = (
    canvas
    .cat_x(df, "x", "y")
    .sort_in_order(["Bob", "Alice"])
    .add_violinplot()
)
```